### PR TITLE
Check if the gap is zero with the decimal precision

### DIFF
--- a/smile_bank_reconciliation/models/account.py
+++ b/smile_bank_reconciliation/models/account.py
@@ -102,7 +102,10 @@ class AccountBankReconciliation(models.Model):
     def button_validate(self):
         self.ensure_one()
         if self.gap:
-            raise exceptions.Warning(_('Invalid action!'), _('Gap must be 0!'))
+            currency_id = self.env.user.company_id.currency_id
+            digits_rounding_precision = currency_id.rounding
+            if not float_is_zero(self.gap,digits_rounding_precision):
+                raise exceptions.Warning(_('Invalid action!'), _('Gap must be 0!'))
         if not self.reconciliation_voucher_ids:
             raise exceptions.Warning(_('Invalid action!'), _('No line in reconciliation voucher!'))
         for reconciliation_voucher in self.reconciliation_voucher_ids:


### PR DESCRIPTION
When exchange rates are used, it is always possible to have a gap of exactly == 0.0
So instead, it is proposed to use the function float_is_zero, with a decimal precision
